### PR TITLE
Feature/completion blocks on main thread (Issue #10)

### DIFF
--- a/Example/MinimalNetworking/ViewController.swift
+++ b/Example/MinimalNetworking/ViewController.swift
@@ -28,15 +28,13 @@ class ViewController: UIViewController {
         let httpService = HttpService()
         _ = httpService.get(url: "https://xkcd.com/info.0.json", responseContentType: ResponseContentType.json) { [weak self] (networkResponse: NetworkResponse<XkcdResponse?>) in
             
-            DispatchQueue.main.async {
-                switch networkResponse {
-                case .success(let xkcd, let response):
-                    self?.getTextView.text = xkcd?.alt
-                    print(response)
-                case .failure(let error):
-                    self?.getTextView.text = error.localizedDescription
-                    self?.getTextView.textColor = UIColor.red
-                }
+            switch networkResponse {
+            case .success(let xkcd, let response):
+                self?.getTextView.text = xkcd?.alt
+                print(response)
+            case .failure(let error):
+                self?.getTextView.text = error.localizedDescription
+                self?.getTextView.textColor = UIColor.red
             }
         }
     }
@@ -44,16 +42,14 @@ class ViewController: UIViewController {
         let httpService = HttpService()
         _ = httpService.post(url: "https://httpbin.org/post", body: PostQuery(), responseContentType: ResponseContentType.json) { [weak self] (networkResponse: NetworkResponse<PostResponse?>) in
             
-            DispatchQueue.main.async {
-                switch networkResponse {
-                case .success(let data, let response):
-                    self?.postTextView.text = data?.form.minimalNetworking
-                    print(response)
-                case .failure(let error):
-                    self?.postTextView.text = error.localizedDescription
-                    self?.postTextView.textColor = UIColor.red
-                    print(error)
-                }
+            switch networkResponse {
+            case .success(let data, let response):
+                self?.postTextView.text = data?.form.minimalNetworking
+                print(response)
+            case .failure(let error):
+                self?.postTextView.text = error.localizedDescription
+                self?.postTextView.textColor = UIColor.red
+                print(error)
             }
         }
     }

--- a/Example/Tests/HTTPServiceTests_GET.swift
+++ b/Example/Tests/HTTPServiceTests_GET.swift
@@ -37,6 +37,7 @@ class HTTPServiceTests_GET: XCTestCase {
         var error: NetworkingServiceError?
         
         _ = subject.get(url: "", responseContentType: ResponseContentType.json, completion: { (responseObject: NetworkResponse<[String: String]?>) in
+            XCTAssert(Thread.isMainThread)
             error = TestUtilities.extractError(from: responseObject, ofType: NetworkingServiceError.invalidURL) as? NetworkingServiceError
         })
         
@@ -47,6 +48,7 @@ class HTTPServiceTests_GET: XCTestCase {
         var error: NetworkingServiceError?
         
         _ = subject.get(url: "https://😂.lol", responseContentType: ResponseContentType.json, completion: { (responseObject: NetworkResponse<[String: String]?>) in
+            XCTAssert(Thread.isMainThread)
             error = TestUtilities.extractError(from: responseObject, ofType: NetworkingServiceError.invalidURL) as? NetworkingServiceError
         })
         
@@ -60,6 +62,18 @@ class HTTPServiceTests_GET: XCTestCase {
         _ = subject.get(url: urlString, responseContentType: ResponseContentType.empty) { (response : NetworkResponse<[String: String]?>) -> Void in }
         
         XCTAssert(dataTask.resumeCalled)
+    }
+    
+    func test_GET_CompletionRunsOnMainThread() {
+        let expectation = XCTestExpectation(description: "Completion block runs on main thread")
+        
+        _ = subject.get(url: urlString, responseContentType: ResponseContentType.empty) { (response : NetworkResponse<[String: String]?>) -> Void in
+            XCTAssert(Thread.isMainThread)
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 5.0)
     }
     
     func test_GET_WithResponseData_ReturnsDecodedData() {

--- a/Example/Tests/HTTPServiceTests_GET.swift
+++ b/Example/Tests/HTTPServiceTests_GET.swift
@@ -65,6 +65,7 @@ class HTTPServiceTests_GET: XCTestCase {
     func test_GET_WithResponseData_ReturnsDecodedData() {
         let encoder = JSONEncoder()
         let expectedData = ["string": "Hello World"]
+        let expectation = XCTestExpectation(description: "Gets and Decodes response data")
         
         session.nextData = try! encoder.encode(expectedData)
         
@@ -74,12 +75,16 @@ class HTTPServiceTests_GET: XCTestCase {
             switch responseObject {
             case .success(let decodedData, _):
                 actualData = decodedData
+                
+                XCTAssert(expectedData == actualData)
+                
+                expectation.fulfill()
             default:
                 break
             }
         })
         
-        XCTAssert(expectedData == actualData)
+        wait(for: [expectation], timeout: 5.0)
     }
     
     func test_GET_WithResponseData_CannotDecodeData_ReturnsError() {
@@ -95,42 +100,58 @@ class HTTPServiceTests_GET: XCTestCase {
         let encoder = JSONEncoder()
         let expectedData = MyStringType(myString: "Hello world")
         session.nextData = try! encoder.encode(expectedData)
+        let expectation = XCTestExpectation(description: "Failed to decode response data and errored")
         
         var error: DecodingError?
         
         _ = subject.get(url: urlString, responseContentType: ResponseContentType.json, completion: { (responseObject: NetworkResponse<MyIntType?>) in
             error = TestUtilities.extractError(from: responseObject) as? DecodingError
+            
+            XCTAssertNotNil(error)
+            
+            expectation.fulfill()
         })
         
-        XCTAssertNotNil(error)
+        wait(for: [expectation], timeout: 5.0)
     }
     
     func test_GET_WithANetworkError_ReturnsANetworkError() {
         session.nextError = NetworkingServiceError.testNetworkError
         
         var error: Error? = nil
+        let expectation = XCTestExpectation(description: "Returned network error")
         
         _ = subject.get(url: urlString, responseContentType: ResponseContentType.json, completion: { (responseObject: NetworkResponse<[String: String]?>) in
             switch responseObject {
             case .failure(let networkError):
                 error = networkError
+                
+                XCTAssertNotNil(error)
+                
+                expectation.fulfill()
             default:
                 break
             }
         })
         
-        XCTAssertNotNil(error)
+        wait(for: [expectation], timeout: 5.0)
     }
     
     func test_GET_InvalidResponse_ReturnsInvalidResponseError() {
         session.nextResponse = nil
         
         var error: NetworkingServiceError?
+        let expectation = XCTestExpectation(description: "Returned invalid response error")
+        
         _ = subject.get(url: urlString, responseContentType: ResponseContentType.json, completion: { (responseObject: NetworkResponse<[String: String]?>) in
             error = TestUtilities.extractError(from: responseObject, ofType: NetworkingServiceError.responseInvalid) as? NetworkingServiceError
+            
+            XCTAssertNotNil(error)
+            
+            expectation.fulfill()
         })
         
-        XCTAssertNotNil(error)
+        wait(for: [expectation], timeout: 5.0)
     }
     
     func test_GET_500StatusCode_ReturnsStatusCodeError() {
@@ -138,26 +159,37 @@ class HTTPServiceTests_GET: XCTestCase {
         session.nextResponse = HTTPURLResponse(url: URL(string: urlString)!, statusCode: expectedCode, httpVersion: nil, headerFields: nil)
         
         var error: NetworkingServiceError?
+        let expectation = XCTestExpectation(description: "Returned status code error with appropriate status code")
         
         _ = subject.get(url: urlString, responseContentType: ResponseContentType.json, completion: { (responseObject: NetworkResponse<[String: String]?>) in
             error = TestUtilities.extractError(from: responseObject, ofType: NetworkingServiceError.statusCode(expectedCode)) as? NetworkingServiceError
+            
+            XCTAssertNotNil(error)
+            
+            expectation.fulfill()
         })
         
-        XCTAssertNotNil(error)
+        wait(for: [expectation], timeout: 5.0)
     }
     
     func test_GET_EmptyDataReturnedWhenExpectingJSON_ReturnsEmptyDataError() {
         var error: NetworkingServiceError?
+        let expectation = XCTestExpectation(description: "Returned empty data error")
         
         _ = subject.get(url: urlString, responseContentType: ResponseContentType.json, completion: { (responseObject: NetworkResponse<[String: String]?>) in
             error = TestUtilities.extractError(from: responseObject, ofType: NetworkingServiceError.dataEmpty) as? NetworkingServiceError
+            
+            XCTAssertNotNil(error)
+            
+            expectation.fulfill()
         })
         
-        XCTAssertNotNil(error)
+        wait(for: [expectation], timeout: 5.0)
     }
     
     func test_GET_ExpectEmptyData_ReturnsNilInNetworkSuccess() {
         let expectedData: [String:String]? = nil
+        let expectation = XCTestExpectation(description: "Returned nil when expected")
         
         var actualData: [String:String]? = [:]
         
@@ -165,12 +197,16 @@ class HTTPServiceTests_GET: XCTestCase {
             switch responseObject {
             case .success(let decodedData, _):
                 actualData = decodedData
+                
+                XCTAssert(actualData == expectedData)
+                
+                expectation.fulfill()
             default:
                 break
             }
         })
         
-        XCTAssert(expectedData == actualData)
+        wait(for: [expectation], timeout: 5.0)
     }
     
     

--- a/Example/Tests/HTTPServiceTests_POST.swift
+++ b/Example/Tests/HTTPServiceTests_POST.swift
@@ -48,6 +48,7 @@ class HTTPServiceTests_POST: XCTestCase {
         var error: NetworkingServiceError?
         
         _ = subject.post(url: "", body: body, responseContentType: ResponseContentType.json, completion: { (responseObject: NetworkResponse<[String: String]?>) in
+            XCTAssert(Thread.isMainThread)
             error = TestUtilities.extractError(from: responseObject, ofType: NetworkingServiceError.invalidURL) as? NetworkingServiceError
         })
         
@@ -58,6 +59,7 @@ class HTTPServiceTests_POST: XCTestCase {
         var error: NetworkingServiceError?
         
         _ = subject.post(url: "https://😂.lol", body: body, responseContentType: ResponseContentType.json, completion: { (responseObject: NetworkResponse<[String: String]?>) in
+            XCTAssert(Thread.isMainThread)
             error = TestUtilities.extractError(from: responseObject, ofType: NetworkingServiceError.invalidURL) as? NetworkingServiceError
         })
         
@@ -77,6 +79,18 @@ class HTTPServiceTests_POST: XCTestCase {
         _ = subject.post(url: urlString, body: body, responseContentType: ResponseContentType.empty) { (response : NetworkResponse<[String: String]?>) -> Void in }
         
         XCTAssert(session.lastRequest?.httpBody == Data(body.nextBody.utf8))
+    }
+    
+    func test_GET_CompletionRunsOnMainThread() {
+        let expectation = XCTestExpectation(description: "Completion block runs on main thread")
+        
+        _ = subject.post(url: urlString, body: body, responseContentType: ResponseContentType.empty) { (response : NetworkResponse<[String: String]?>) -> Void in
+            XCTAssert(Thread.isMainThread)
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 5.0)
     }
     
     func test_POST_WithResponseData_ReturnsDecodedData() {

--- a/MinimalNetworking/Classes/HttpService.swift
+++ b/MinimalNetworking/Classes/HttpService.swift
@@ -74,7 +74,9 @@ public class HttpService {
             } catch {
                 networkResponse = .failure(error)
             }
-            completion(networkResponse)
+            DispatchQueue.main.async {
+                completion(networkResponse)
+            }
         })
         return task
     }

--- a/README.md
+++ b/README.md
@@ -27,13 +27,11 @@ _ = httpService.get(url: "url_to_hit",
                     responseContentType: ResponseContentType.json, 
                     additionalHeaders: ["Accept": "application/json"]) 
 { (networkResponse: NetworkResponse<ParsedServerData?>) in
-    DispatchQueue.main.async {
-        switch networkResponse {
-        case .success(let parsedData, let response):
-            //use your data
-        case .failure(let error):
-            //handle the error
-        }
+    switch networkResponse {
+    case .success(let parsedData, let response):
+        //use your data
+    case .failure(let error):
+        //handle the error
     }
 }
 ```


### PR DESCRIPTION
Made it so that completion handler always executes on the main thread.

This required a refactoring of all tests that involved asynchronous behavior to use XCTestExpectation. This test refactoring forms the bulk of the merge changes.

Appropriate changes were also made to the Readme and the Example project.

This PR will resolve #10 